### PR TITLE
Apply HUD and UI refinements

### DIFF
--- a/lia_hoss_6/index.css
+++ b/lia_hoss_6/index.css
@@ -134,12 +134,18 @@ body {
 .vector-item-label .symbol {
     font-family: var(--font-primary);
     color: var(--text-color);
+    min-width: 0; /* Allow shrinking in flex layout */
+    overflow-wrap: break-word; /* Allow long words to break */
+    margin-right: 0.5rem; /* Add a small gap between symbol and value if they get close */
 }
 
 .vector-item-label .value {
     color: var(--primary-glow);
     font-weight: 700;
     text-shadow: 0 0 3px var(--primary-glow);
+    min-width: 0; /* Allow shrinking */
+    overflow-wrap: break-word;
+    text-align: right;
 }
 
 .vector-item-label .status-value {
@@ -148,6 +154,9 @@ body {
     font-family: var(--font-primary);
     text-transform: uppercase;
     font-size: 0.9rem;
+    min-width: 0; /* Allow shrinking */
+    overflow-wrap: break-word;
+    text-align: right;
 }
 
 
@@ -953,7 +962,7 @@ body {
 
   /* Default for < 1600px viewport (specifically targets viewports between 1200px and 1599.98px due to media query order) */
   left: calc(var(--app-padding-desktop) + var(--col1-width-desktop) + var(--grid-gap-desktop));
-  width: calc(100vw - (2 * var(--app-padding-desktop)) - var(--col1-width-desktop) - var(--col3-width-desktop) - (2 * var(--grid-gap-desktop)));
+  width: calc((100vw - (2 * var(--app-padding-desktop)) - var(--col1-width-desktop) - var(--col3-width-desktop) - (2 * var(--grid-gap-desktop))) * 0.99);
   right: auto;
   transform: none;
 }
@@ -963,7 +972,7 @@ body {
   .hud-container {
     left: calc(((100vw - var(--app-max-width)) / 2) + var(--app-padding-desktop) + var(--col1-width-desktop) + var(--grid-gap-desktop));
     /* Width of the 1fr column when app-container is 1600px wide */
-    width: calc(var(--app-max-width) - var(--col1-width-desktop) - var(--col3-width-desktop) - (2 * var(--grid-gap-desktop)));
+    width: calc((var(--app-max-width) - var(--col1-width-desktop) - var(--col3-width-desktop) - (2 * var(--grid-gap-desktop))) * 0.99);
   }
 }
 
@@ -972,7 +981,7 @@ body {
 @media (max-width: 1199.98px) {
   .hud-container {
     left: calc(var(--app-padding-tablet) + var(--col1-width-tablet) + var(--grid-gap-tablet));
-    width: calc(100vw - (2 * var(--app-padding-tablet)) - var(--col1-width-tablet) - var(--col3-width-tablet) - (2 * var(--grid-gap-tablet)));
+    width: calc((100vw - (2 * var(--app-padding-tablet)) - var(--col1-width-tablet) - var(--col3-width-tablet) - (2 * var(--grid-gap-tablet))) * 0.99);
   }
 }
 

--- a/lia_hoss_6/index.tsx
+++ b/lia_hoss_6/index.tsx
@@ -471,9 +471,20 @@ Do not wrap the JSON in markdown or any other text.`;
         <h1 class="bootstrap-title">OMNILAB INITIALIZATION</h1>
         <p class="bootstrap-step">${BOOTSTRAP_SEQUENCE[bootstrapStep] || BOOTSTRAP_SEQUENCE[BOOTSTRAP_SEQUENCE.length - 1]}</p>
         <div class="bootstrap-actions">
-           <button class="help-btn" onClick=${() => setShowManual(true)} aria-label="Open System Manual">
+           <button class="help-btn" onClick=${() => setShowManual(true)} aria-label="Open System Manual" title="Open System Manual">
              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><line x1="10" y1="9" x2="8" y2="9"></line></svg>
            </button>
+            <button class="help-btn hud-toggle-btn bootstrap-hud-toggle" onClick=${() => setShowHud(prev => !prev)} aria-label="Toggle HUD" title="Toggle HUD Visibility">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                ${showHud ? html`
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                  <line x1="1" y1="1" x2="23" y2="23"></line>
+                ` : html`
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                  <circle cx="12" cy="12" r="3"></circle>
+                `}
+              </svg>
+            </button>
            <button class="operator-btn bootstrap-btn" onClick=${handleBootstrapClick} disabled=${isBootstrapping}>
              ${isBootstrapping ? 'Initializing...' : 'Engage'}
            </button>


### PR DESCRIPTION
- Reduced HUD width by 1% in relevant viewport configurations.
- Fixed horizontal scrollbar issue in the State Vectors panel by enabling text wrapping and shrinking for its items.
- Added a HUD toggle button to the bootstrap/initialization screen, allowing control over HUD visibility before the main interface loads.