### PR TITLE
Integrate Sectorforth emulator into lia-hoss UI

### DIFF
--- a/lia_hoss/LIA_FC_Sectorforth/create_html.sh
+++ b/lia_hoss/LIA_FC_Sectorforth/create_html.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-# Directory containing the JSON chunks
+# Directory containing the JSON chunks (relative to this script's location)
 chunks_dir="outputs/chunks"
 
-# The HTML file to be created
-output_html="chunky.html"
+# Define project root relative to script location (e.g. if script is in my_project/src/scripts, project_root is ../../)
+# Assuming this script is in lia_hoss/src/LIA_FC_Sectorforth/
+PROJECT_ROOT_REL_FROM_SCRIPT_DIR="../../"
+PUBLIC_ASSET_DIR="${PROJECT_ROOT_REL_FROM_SCRIPT_DIR}public/LIA_FC_Sectorforth"
+
+# Create the public asset directory if it doesn't exist
+mkdir -p "$PUBLIC_ASSET_DIR"
+
+# The HTML file to be created in the public asset directory
+output_html="${PUBLIC_ASSET_DIR}/chunky.html"
 
 # Start the HTML file with some basic structure
 echo '<!DOCTYPE html>' > $output_html

--- a/lia_hoss/index.tsx
+++ b/lia_hoss/index.tsx
@@ -294,6 +294,7 @@ function App() {
   const [activeOperator, setActiveOperator] = useState('Send');
   const [showManual, setShowManual] = useState(false);
   const [showHud, setShowHud] = useState(true); // Added state for HUD visibility
+  const [showEmulatorWindow, setShowEmulatorWindow] = useState(false); // State for emulator window
   const logRef = useRef(null);
   const chatRef = useRef(null);
 
@@ -561,6 +562,10 @@ Do not wrap the JSON in markdown or any other text.`;
                 <button class="help-btn" onClick=${() => setShowManual(true)} aria-label="Open System Manual" title="Open System Manual">
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><line x1="10" y1="9" x2="8" y2="9"></line></svg>
                 </button>
+                {/* Emulator Button Added Here */}
+                <button class="help-btn" onClick=${() => setShowEmulatorWindow(true)} aria-label="Launch Emulator" title="Launch Sectorforth Emulator">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
+                </button>
                 <button class="help-btn hud-toggle-btn" onClick=${() => setShowHud(prev => !prev)} aria-label="Toggle HUD" title="Toggle HUD">
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     ${showHud ? html`
@@ -640,6 +645,7 @@ Do not wrap the JSON in markdown or any other text.`;
         </div>
       </div>
       ${showManual && html`<${SystemManual} onClose=${() => setShowManual(false)} />`}
+      <${EmulatorWindow} isVisible=${showEmulatorWindow} onClose=${() => setShowEmulatorWindow(false)} />
     </div>
   `;
 }


### PR DESCRIPTION
- Added an 'Emulator' button to the main interaction panel in index.tsx.
- Implemented a floating window (modal) using Preact to display the emulator.
- The floating window loads LIA_FC_Sectorforth/start.html in an iframe.
- Modified LIA_FC_Sectorforth/create_html.sh to output chunky.html to the public assets directory for proper serving by Vite.
- Provided instructions for manual asset placement and testing.