### PR TITLE
Feat: Add launch buttons for FreeDOS and Sectorforth emulators to lan…

### DIFF
--- a/lia_hoss/index.css
+++ b/lia_hoss/index.css
@@ -1116,3 +1116,40 @@ body {
   text-shadow: 0 0 1px var(--primary-glow); /* Adjusted shadow */
   min-width: 20px; /* Adjusted min-width */
 }
+
+/* Styles for Emulator Launch Buttons on index.html */
+.emulator-launch-section {
+  display: flex;
+  flex-direction: column; /* Stack buttons vertically */
+  align-items: center;    /* Center buttons horizontally */
+  gap: 1rem;                /* Space between buttons */
+  margin-bottom: 2rem;      /* Space below the buttons, before the #root app */
+  padding: 1rem;
+  position: relative; /* To ensure it's above the main app if it's absolutely positioned */
+  z-index: 10; /* Above default content, below modals/HUD if any */
+}
+
+.emulator-launch-btn {
+  font-family: var(--font-primary);
+  font-size: 1rem;
+  color: var(--primary-glow);
+  background: transparent;
+  border: 2px solid var(--primary-glow);
+  padding: 0.75rem 1.5rem; /* Slightly more padding for main page buttons */
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-shadow: 0 0 5px var(--primary-glow);
+  box-shadow: 0 0 5px var(--primary-glow), inset 0 0 5px rgba(0, 255, 255, 0.3); /* Adjusted inset shadow */
+  text-decoration: none; /* Remove underline from <a> tags */
+  display: inline-block; /* Behaves like a button */
+  text-align: center;
+}
+
+.emulator-launch-btn:hover,
+.emulator-launch-btn:focus {
+  color: var(--background-color);
+  background: var(--primary-glow);
+  box-shadow: 0 0 15px var(--primary-glow), 0 0 10px var(--primary-glow);
+  text-shadow: 0 0 3px var(--background-color); /* Ensure text is readable on hover */
+}

--- a/lia_hoss/index.html
+++ b/lia_hoss/index.html
@@ -26,6 +26,10 @@
   <link rel="stylesheet" href="/index.css">
 </head>
   <body>
+    <div class="emulator-launch-section">
+      <a href="public/LIA_FC-Freedos-Tiny/start.html" class="emulator-launch-btn">Launch FreeDOS Tiny Emulator</a>
+      <a href="public/LIA_FC_Sectorforth/start.html" class="emulator-launch-btn">Launch Sectorforth Emulator</a>
+    </div>
     <div id="root"></div>
     <script type="module" src="index.tsx"></script>
   <script type="module" src="/index.tsx"></script>


### PR DESCRIPTION
…ding page

- Added two buttons to lia_hoss/index.html that link to the FreeDOS Tiny and Sectorforth emulator start pages.
- Styled these buttons using CSS in lia_hoss/index.css, consistent with the existing site theme.
- The buttons are positioned above the main application root for easy access.